### PR TITLE
Uses BoundIterator with Tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,7 @@ int main(int argc, char **argv) {
 ## Unit tests
 ```bash
 # Build
-$ cd build/
-$ cmake -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=Debug ..
-$ cmake --build .
+$ make build
 # Run
-$ ./tests/parser_tests
-$ ./tests/lexer_tests
+$ make unittests
 ```

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_executable(json_parsing json_parsing.cc)
+add_executable(parsing_from_file parsing_from_file.cc)

--- a/examples/parsing_from_file.cc
+++ b/examples/parsing_from_file.cc
@@ -1,0 +1,18 @@
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "minijson.h"
+
+int main(int argc, char **argv) {
+
+  std::ifstream file_stream("examples/parsing_from_file_example.json");
+  minijson::JSONNode json = minijson::Parse(&file_stream);
+
+  std::cout
+      << "\"inner_key\" contains: "
+      << json["nested_obj_key"]["nested_arr_key"][2]["inner_obj_key"].GetStr()
+      << std::endl;
+
+  return 0;
+}

--- a/examples/parsing_from_file_example.json
+++ b/examples/parsing_from_file_example.json
@@ -1,0 +1,15 @@
+{
+  "str_key": "hello, world",
+  "num_key": 123,
+  "null_key": null,
+  "true_key": true,
+  "nested_obj_key": {
+    "nested_arr_key": [
+      "elem1",
+      "elem2",
+      {
+        "inner_obj_key": "ok!"
+      },
+    ]
+  }
+}

--- a/minijson.h
+++ b/minijson.h
@@ -91,7 +91,7 @@ private:
   Iter end_;
 };
 
-Token TokenizeString(std::string::const_iterator *it) {
+Token TokenizeString(BoundIterator<std::string::const_iterator> *it) {
   std::string out;
   while (*(++*it) != '"') {
     if (**it == '\\') {
@@ -105,23 +105,24 @@ Token TokenizeString(std::string::const_iterator *it) {
   return Token{TokenType::kStr, out};
 }
 
-Token TokenizeNumber(std::string::const_iterator *it) {
+Token TokenizeNumber(BoundIterator<std::string::const_iterator> *it) {
   auto start = *it;
-  while (isdigit(*(++*it)) || **it == '.')
+  while (!(++*it).end() && (isdigit(**it) || **it == '.'))
     ;
   return Token{TokenType::kNumber, std::string(start, *it)};
 }
 
 bool IsNameChar(char c) { return isalnum(c) || c == '_' || c == '-'; }
 
-Token TokenizeName(std::string::const_iterator *it) {
+Token TokenizeName(BoundIterator<std::string::const_iterator> *it) {
   auto start = *it;
   while (IsNameChar(*++*it))
     ;
   return Token{TokenType::kConstant, std::string(start, *it)};
 }
 
-std::optional<Token> TonekizeOne(std::string::const_iterator *it) {
+std::optional<Token>
+TonekizeOne(BoundIterator<std::string::const_iterator> *it) {
   if (**it == '{') {
     return Token{TokenType::kLCurlyBracket, std::string(*it, ++*it)};
   } else if (**it == '}') {
@@ -149,7 +150,7 @@ std::optional<Token> TonekizeOne(std::string::const_iterator *it) {
 
 std::vector<Token> Tokenize(const std::string &input) {
   std::vector<Token> tokens;
-  for (auto it = input.begin(); it != input.end();) {
+  for (BoundIterator it(input.begin(), input.end()); !it.end();) {
     std::optional<Token> token = TonekizeOne(&it);
     if (token.has_value()) {
       tokens.push_back(token.value());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ if (CMAKE_VERSION VERSION_LESS 2.8.11)
                       "${gmock_SOURCE_DIR}/include")
 endif()
 
-add_executable(tokenizer_tests lexer_tests.cc)
+add_executable(tokenizer_tests tokenizer_tests.cc)
 target_link_libraries(tokenizer_tests gtest_main gmock_main)
 add_test(NAME tokenizer_tests COMMAND tokenizer_tests)
 

--- a/tests/parser_tests.cc
+++ b/tests/parser_tests.cc
@@ -199,5 +199,19 @@ TEST(Parser, ThrowOnLeftover) {
   ASSERT_THROW(Parse(text), std::runtime_error);
 }
 
+TEST(Parser, ThrowOnMalformedArrayMissingClosingBracket) {
+  const std::string text = R"(
+    [true, false
+  )";
+  ASSERT_THROW(Parse(text), std::runtime_error);
+}
+
+TEST(Parser, ThrowOnMalformedArrayMissingComma) {
+  const std::string text = R"(
+    [true false]
+  )";
+  ASSERT_THROW(Parse(text), std::runtime_error);
+}
+
 } // namespace
 } // namespace minijson

--- a/tests/tokenizer_tests.cc
+++ b/tests/tokenizer_tests.cc
@@ -74,5 +74,13 @@ TEST(Tokenizer, FloatingPointWorks) {
               ::testing::ElementsAre(Token{TokenType::kNumber, "123.123"}));
 }
 
+TEST(Tokenizer, ThrowOnMalformedString) {
+  // Missing closing quotes.
+  const std::string json = R"(
+    "Ok!
+  )";
+  ASSERT_THROW(Tokenize(json), std::runtime_error);
+}
+
 } // namespace
 } // namespace minijson::internal

--- a/tests/tokenizer_tests.cc
+++ b/tests/tokenizer_tests.cc
@@ -27,7 +27,8 @@ TEST(Tokenizer, TokenizeSmokeTest) {
       }
     }
   )";
-  auto tokens = Tokenize(json);
+  std::istringstream stream(json);
+  auto tokens = Tokenize(&stream);
   ASSERT_THAT(
       tokens,
       ::testing::ElementsAre(
@@ -56,7 +57,8 @@ TEST(Tokenizer, UnderstandEscapeSequences) {
   const std::string json = R"(
     "It goes:\n\"Muchos años después, frente al pelotón de fusilamiento (...)\""
   )";
-  auto tokens = Tokenize(json);
+  std::istringstream stream(json);
+  auto tokens = Tokenize(&stream);
   ASSERT_THAT(tokens, ::testing::ElementsAre(
                           Token{TokenType::kStr,
                                 "It goes:\\n\\\"Muchos años después, frente al "
@@ -64,14 +66,24 @@ TEST(Tokenizer, UnderstandEscapeSequences) {
 }
 
 TEST(Tokenizer, IntegerWorks) {
-  auto tokens = Tokenize("123");
+  std::istringstream stream("123");
+  auto tokens = Tokenize(&stream);
   ASSERT_THAT(tokens, ::testing::ElementsAre(Token{TokenType::kNumber, "123"}));
 }
 
 TEST(Tokenizer, FloatingPointWorks) {
-  auto tokens = Tokenize("123.123");
+  std::istringstream stream("123.123");
+  auto tokens = Tokenize(&stream);
   ASSERT_THAT(tokens,
               ::testing::ElementsAre(Token{TokenType::kNumber, "123.123"}));
+}
+
+TEST(Tokenizer, ObjectWorks) {
+  std::istringstream stream("{}");
+  auto tokens = Tokenize(&stream);
+  ASSERT_THAT(tokens,
+              ::testing::ElementsAre(Token{TokenType::kLCurlyBracket, "{"},
+                                     Token{TokenType::kRCurlyBracket, "}"}));
 }
 
 TEST(Tokenizer, ThrowOnMalformedString) {
@@ -79,7 +91,8 @@ TEST(Tokenizer, ThrowOnMalformedString) {
   const std::string json = R"(
     "Ok!
   )";
-  ASSERT_THROW(Tokenize(json), std::runtime_error);
+  std::istringstream stream(json);
+  ASSERT_THROW(Tokenize(&stream), std::runtime_error);
 }
 
 } // namespace


### PR DESCRIPTION
- Incrementing pass the end or dereferencing an invalid address should
now throw an error in the tokenization process.

- Uses std::istream for input, instead of std::strings. The function
Parse(std::string) is kept for convenience.